### PR TITLE
Specify python3.7 for interproscan

### DIFF
--- a/FunctionalAnnotation/conda/process_interproscan.yml
+++ b/FunctionalAnnotation/conda/process_interproscan.yml
@@ -7,3 +7,4 @@ channels:
 
 dependencies:
   - openjdk>=11.0.1
+  - python=3.7


### PR DESCRIPTION
One of the utilities used by interproscan requires python3 to not be 3.8. Specify 3.7 to avoid such issues.