### PR TITLE
Patch interproscan. Disable container, use Uppmax module / conda env.

### DIFF
--- a/FunctionalAnnotation/config/software_packages.config
+++ b/FunctionalAnnotation/config/software_packages.config
@@ -6,8 +6,16 @@ process {
     withName: interproscan {
         // NOTE: Interproscan is not currently installed through conda. It must be added separately to your PATH.
         // see `nbis` profile for an example of how.
-        conda = { singularity.enabled || docker.enabled ? '' : "$baseDir/conda/process_interproscan.yml" }
-        container = 'biocontainers/interproscan:v5.30-69.0_cv3'
+        // conda = { singularity.enabled || docker.enabled ? '' : "$baseDir/conda/process_interproscan.yml" }
+        if( workflow.profile == "uppmax" ) {
+            // use Uppmax module
+            module 'bioinfo-tools:InterProScan/5.30-69.0'
+        } else {
+            // Use conda profile and provide Interoproscan via the PATH.
+            conda = "$baseDir/conda/process_interproscan.yml"
+        }
+        The container does not function correctly. Waiting for a biocontainers container.
+        // container = 'biocontainers/interproscan:v5.30-69.0_cv3'
     }
     withLabel: 'AGAT' {
         conda = { singularity.enabled || docker.enabled ? '' : "$baseDir/conda/label_agat.yml" }

--- a/FunctionalAnnotation/config/software_packages.config
+++ b/FunctionalAnnotation/config/software_packages.config
@@ -7,14 +7,9 @@ process {
         // NOTE: Interproscan is not currently installed through conda. It must be added separately to your PATH.
         // see `nbis` profile for an example of how.
         // conda = { singularity.enabled || docker.enabled ? '' : "$baseDir/conda/process_interproscan.yml" }
-        if( workflow.profile == "uppmax" ) {
-            // use Uppmax module
-            module 'bioinfo-tools:InterProScan/5.30-69.0'
-        } else {
-            // Use conda profile and provide Interoproscan via the PATH.
-            conda = "$baseDir/conda/process_interproscan.yml"
-        }
-        // The container does not function correctly. Waiting for a biocontainers container.
+        // Use conda environment by default and provide Interoproscan via the PATH.
+        conda = "$baseDir/conda/process_interproscan.yml"
+        // The container does not function correctly. Waiting for a functioning biocontainers container.
         // container = 'biocontainers/interproscan:v5.30-69.0_cv3'
     }
     withLabel: 'AGAT' {

--- a/FunctionalAnnotation/config/software_packages.config
+++ b/FunctionalAnnotation/config/software_packages.config
@@ -14,7 +14,7 @@ process {
             // Use conda profile and provide Interoproscan via the PATH.
             conda = "$baseDir/conda/process_interproscan.yml"
         }
-        The container does not function correctly. Waiting for a biocontainers container.
+        // The container does not function correctly. Waiting for a biocontainers container.
         // container = 'biocontainers/interproscan:v5.30-69.0_cv3'
     }
     withLabel: 'AGAT' {

--- a/FunctionalAnnotation/config/software_packages_uppmax.config
+++ b/FunctionalAnnotation/config/software_packages_uppmax.config
@@ -1,0 +1,12 @@
+process {
+    withLabel: blast {
+        container = 'quay.io/biocontainers/blast:2.9.0--pl526h3066fca_4'
+    }
+    withName: interproscan {
+        // use Uppmax module
+        module 'bioinfo-tools:InterProScan/5.30-69.0'
+    }
+    withLabel: 'AGAT' {
+        container = 'quay.io/biocontainers/agat:0.5.1--pl526r35_0'
+    }
+}

--- a/FunctionalAnnotation/config/software_packages_uppmax.config
+++ b/FunctionalAnnotation/config/software_packages_uppmax.config
@@ -4,7 +4,7 @@ process {
     }
     withName: interproscan {
         // use Uppmax module
-        module 'bioinfo-tools:InterProScan/5.30-69.0'
+        module = 'bioinfo-tools:InterProScan/5.30-69.0'
     }
     withLabel: 'AGAT' {
         container = 'quay.io/biocontainers/agat:0.5.1--pl526r35_0'

--- a/FunctionalAnnotation/nextflow.config
+++ b/FunctionalAnnotation/nextflow.config
@@ -20,7 +20,7 @@ profiles {
         includeConfig "$baseDir/config/compute_resources.config"
         singularity.enabled = true
         singularity.envWhitelist = 'SNIC_TMP'
-        includeConfig "$baseDir/config/software_packages.config"
+        includeConfig "$baseDir/config/software_packages_uppmax.config"
     }
 
     conda {


### PR DESCRIPTION
In order to still be able to use singularity I patched the config instead to check the profile in use. 
The config should now load Interproscan from the module system when using the profile `uppmax`. 
@verku could you test if this is viable?