### PR TITLE
Update Busco to 5.2.2 and container entrypoint fix.

### DIFF
--- a/AbinitioTraining/nextflow.config
+++ b/AbinitioTraining/nextflow.config
@@ -27,7 +27,12 @@ profiles {
         includeConfig "$baseDir/config/software_packages.config"
     }
 
-    debug { process.beforeScript = 'env' }
+    mamba {
+        includeConfig "$baseDir/config/software_packages.config"
+        conda.useMamba = true
+    }
+
+   debug { process.beforeScript = 'env' }
 
     docker {
         docker.enabled = true

--- a/AnnotationPreprocessing/conda/process_busco.yml
+++ b/AnnotationPreprocessing/conda/process_busco.yml
@@ -6,4 +6,4 @@ channels:
   - defaults
 
 dependencies:
-  - busco=5.0.0
+  - busco=5.2.2

--- a/AnnotationPreprocessing/config/software_packages.config
+++ b/AnnotationPreprocessing/config/software_packages.config
@@ -5,6 +5,6 @@ process {
     }
     withName: 'busco' {
         conda = { singularity.enabled || docker.enabled ? '' : "$baseDir/conda/process_busco.yml" }
-        container = 'ezlabgva/busco:v5.0.0_cv1'
+        container = 'quay.io/biocontainers/busco:5.2.2--pyhdfd78af_0'
     }
 }

--- a/AnnotationPreprocessing/nextflow.config
+++ b/AnnotationPreprocessing/nextflow.config
@@ -27,6 +27,11 @@ profiles {
         includeConfig "$baseDir/config/software_packages.config"
     }
 
+    mamba {
+        includeConfig "$baseDir/config/software_packages.config"
+        conda.useMamba = true
+    }
+
     singularity {
         singularity.enabled = true
         includeConfig "$baseDir/config/software_packages.config"

--- a/FunctionalAnnotation/nextflow.config
+++ b/FunctionalAnnotation/nextflow.config
@@ -27,6 +27,11 @@ profiles {
         includeConfig "$baseDir/config/software_packages.config"
     }
 
+    mamba {
+        includeConfig "$baseDir/config/software_packages.config"
+        conda.useMamba = true
+    }
+
     singularity {
         singularity.enabled = true
         includeConfig "$baseDir/config/software_packages.config"

--- a/TranscriptAssembly/nextflow.config
+++ b/TranscriptAssembly/nextflow.config
@@ -27,6 +27,11 @@ profiles {
         includeConfig "$baseDir/config/software_packages.config"
     }
 
+    mamba {
+        includeConfig "$baseDir/config/software_packages.config"
+        conda.useMamba = true
+    }
+
     debug { process.beforeScript = 'env' }
 
     docker {


### PR DESCRIPTION
Update Busco to 5.2.2
Fixes error arising from changed container entrypoint
```
.command.sh: line 2: AUGUSTUS_CONFIG_PATH: unbound variable
```
Include mamba profiles

Closes #68 

Notes: 
Conda seems to run out of memory creating environment Error code 143
Mamba has some other error, Error code 120. 