### PR TITLE
Reduce high mem value to 120 from 200 GB

### DIFF
--- a/config/nf-core-defaults.config
+++ b/config/nf-core-defaults.config
@@ -31,6 +31,6 @@ process {
         time   = 20.h
     }
     withLabel: process_high_memory {
-        memory = 200.GB
+        memory = 120.GB
     }
 }


### PR DESCRIPTION
Reduce the high memory default from 200 to 120GB to account for max memory on Rackham.
Fixes #81 