### PR TITLE
Increasing time for process_single

### DIFF
--- a/config/nf-core-defaults.config
+++ b/config/nf-core-defaults.config
@@ -9,8 +9,8 @@ process {
 
     withLabel: process_single {
         cpus   = 1
-        memory = 6.GB
-        time   = 2.h
+        memory = 12.GB
+        time   = 24.h
     }
     withLabel: process_low {
         cpus   = 2


### PR DESCRIPTION
This is so Interproscan and other process_single processes don't hang, since they usually require much longer runtimes. I've increased a bit memory too.