### PR TITLE
Patch issue100

### DIFF
--- a/config/functional_annotation_modules.config
+++ b/config/functional_annotation_modules.config
@@ -27,8 +27,9 @@ process {
     }
     withName: 'MERGE_FUNCTIONAL_ANNOTATION' {
         ext.args = [
-            '-id NBIS',
-            '-pe 5'
+            "-id $params.merge_annotation_identifier",
+            '-pe 5',
+            params.use_pcds ? "--pcds" : ""
         ].join(' ').trim()
         publishDir = [
             [

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ params {
     gff_annotation = '/path/to/annotation.gff'
     records_per_file = 1000
     blast_db_fasta = '/path/to/protein/database.fasta'
-    merge_annotation_identifier = 'ID'
+    merge_annotation_identifier = 'NBIS'
 
     // Transcript assembly parameters
     reads = "/path/to/reads_{1,2}.fastq.gz"

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,6 +34,7 @@ params {
     records_per_file = 1000
     blast_db_fasta = '/path/to/protein/database.fasta'
     merge_annotation_identifier = 'NBIS'
+    use_pcds = false
 
     // Transcript assembly parameters
     reads = "/path/to/reads_{1,2}.fastq.gz"

--- a/subworkflows/functional_annotation/README.md
+++ b/subworkflows/functional_annotation/README.md
@@ -51,6 +51,9 @@ nextflow run NBISweden/pipelines-nextflow \
   - `outdir`: Path to the results folder.
   - `records_per_file`: Number of fasta records per file to distribute to blast and interproscan (default: 1000).
   - `codon_table`: (default: 1).
+  - `blast_db_fasta` : Path to blast protein database fasta.
+  - `merge_annotation_identifier`: The identifier to use for labeling genes (default: NBIS).
+  - `use_pcds`: If true, enables the pcds flag when merging annotation.
 
 ### Tool specific parameters
 


### PR DESCRIPTION
Fixes #100 

- Fixes params.merge_annotation_identifier usage in MERGE_FUNCTIONAL_ANNOTATION.
- Adds a new parameter, `use_pcds` to enable pcds in merging functional annotation process.\
- Updates README with parameters