### PR TITLE
Interproscan

### DIFF
--- a/config/functional_annotation_modules.config
+++ b/config/functional_annotation_modules.config
@@ -16,11 +16,13 @@ process {
         ext.args = '-evalue 1e-6 -outfmt 6'
     }
     withName: 'INTERPROSCAN' {
+        cpus = 8
         ext.args = [
             '--iprlookup',
             '--goterms', 
             '-pa', 
             '-t p'
+            '-dra'
         ].join(' ').trim()
     }
     withName: 'MERGE_FUNCTIONAL_ANNOTATION' {

--- a/config/functional_annotation_modules.config
+++ b/config/functional_annotation_modules.config
@@ -19,9 +19,9 @@ process {
         cpus = 8
         ext.args = [
             '--iprlookup',
-            '--goterms', 
-            '-pa', 
-            '-t p'
+            '--goterms',
+            '-pa',
+            '-t p',
             '-dra'
         ].join(' ').trim()
     }


### PR DESCRIPTION
- add missing default cpus = 8 argument back to functional annotation pipeline 
- add -dra option for minor speedup